### PR TITLE
feat: Evaluate complex expressions

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -254,15 +254,15 @@ rule asd {
         pe.entry<$>_point == 123 and
         cuckoo.sync.mutex(/test/)
 }""",
-            yaramod.EqExpression,
-            utils.range_from_coords((4, 8), (4, 29)),
+            yaramod.StructAccessExpression,
+            utils.range_from_coords((4, 8), (4, 22)),
         ),
         (
             """import "cuckoo"
 import "pe"
 rule asd {
     condition:
-        pe.entry<$>_point != 123 and
+        pe.entry_point <$>!= 123 and
         cuckoo.sync.mutex(/test/)
 }""",
             yaramod.NeqExpression,
@@ -273,7 +273,7 @@ rule asd {
 import "pe"
 rule asd {
     condition:
-        pe.entry<$>_point >= 123 and
+        pe.entry_point <$>>= 123 and
         cuckoo.sync.mutex(/test/)
 }""",
             yaramod.GeExpression,
@@ -284,7 +284,7 @@ rule asd {
 import "pe"
 rule asd {
     condition:
-        pe.entry<$>_point > 123 and
+        pe.entry_point <$>> 123 and
         cuckoo.sync.mutex(/test/)
 }""",
             yaramod.GtExpression,
@@ -295,7 +295,7 @@ rule asd {
 import "pe"
 rule asd {
     condition:
-        pe.entry<$>_point <= 123 and
+        pe.entry_point <$><= 123 and
         cuckoo.sync.mutex(/test/)
 }""",
             yaramod.LeExpression,
@@ -306,11 +306,11 @@ rule asd {
 import "pe"
 rule asd {
     condition:
-        pe.entry<$>_point < 123 and
+        pe.entry_point<$> < 123 and
         cuckoo.sync.mutex(/test/)
 }""",
-            yaramod.LtExpression,
-            utils.range_from_coords((4, 8), (4, 28)),
+            yaramod.StructAccessExpression,
+            utils.range_from_coords((4, 8), (4, 22)),
         ),
         (
             """import "cuckoo"
@@ -320,7 +320,7 @@ rule asd {
         fa<$>lse
 }""",
             None,
-            utils.range_from_coords((4, 8), (4, 28)),
+            utils.range_from_coords((4, 8), (4, 22)),
         ),
     ],
 )

--- a/yls/hookspecs.py
+++ b/yls/hookspecs.py
@@ -108,10 +108,10 @@ class EvalError:
 
 
 @hookspec
-def yls_eval(ls: Any, document: Document, position: Position) -> PluggyRes[str | EvalError]:
+def yls_eval(ls: Any, expr: str) -> PluggyRes[str | EvalError]:
     ...
 
 
 @hookspec
-def yls_eval_set_context(ls: Any, _hash: str) -> PluggyRes[str | EvalError]:
+def yls_eval_set_context(ls: Any, _hash: str, ruleset: str) -> PluggyRes[str | EvalError]:
     ...

--- a/yls/hookspecs.py
+++ b/yls/hookspecs.py
@@ -28,7 +28,6 @@ from pygls.lsp.types import CompletionParams
 from pygls.lsp.types import Diagnostic
 from pygls.lsp.types import DocumentFormattingParams
 from pygls.lsp.types import MessageType
-from pygls.lsp.types import Position
 from pygls.lsp.types import TextEdit
 from pygls.workspace import Document
 

--- a/yls/hover.py
+++ b/yls/hover.py
@@ -47,7 +47,7 @@ class Hoverer:
                     f"""{self.result_to_markdown(eval_result)}
 *Expression*:
 ```
-{utils.display_oneline_expr(expr)}
+{utils.remove_whitespace(expr)}
 ```
 
 """

--- a/yls/hover.py
+++ b/yls/hover.py
@@ -18,6 +18,7 @@ log = logging.getLogger(__name__)
 class Hoverer:
     def __init__(self, ls: Any) -> None:
         self.ls = ls
+        self.selected_range = None
 
     async def hover(self, params: lsp_types.TextDocumentPositionParams) -> lsp_types.Hover | None:
 
@@ -26,6 +27,29 @@ class Hoverer:
 
         if self.ls.debug_hover:
             return utils.debug_hover(document, position)
+
+        # Evaluate entire block of selected expressions
+        if (
+            self.selected_range
+            and self.selected_range.start != self.selected_range.end
+            and utils.position_in_range(position, self.selected_range)
+        ):
+            expr_range = utils.range_to_expression(document, self.selected_range)
+            if not expr_range:
+                return None
+
+            expr = utils.text_from_range(document, expr_range)
+            log.debug('[HOVER] Hover request with selected text "{}"'.format(expr))
+            eval_result = await self.eval_expression(expr)
+            log.debug(f"[HOVER] Evaluation returned {eval_result}")
+            return lsp_types.Hover(
+                contents=utils.markdown_content(
+                    "{}\n"
+                    "*Expression*:\n```\n{}\n```\n\n".format(
+                        self.result_to_markdown(eval_result), utils.display_oneline_expr(expr)
+                    )
+                )
+            )
 
         token = utils.cursor_token(document, position)
 
@@ -37,7 +61,7 @@ class Hoverer:
 
         log.debug(f'[HOVER] Hover request with token "{token}" and type "{token.type}"')
         if token.type == yaramod.TokenType.StringId:
-            return self.hover_string(token, document, position)
+            return await self.hover_string(token, document, position)
         elif token.type == yaramod.TokenType.Id:
             yara_file = utils.yaramod_parse_file(document.path)
             if yara_file is None:
@@ -45,9 +69,7 @@ class Hoverer:
 
             for rule in yara_file.rules:
                 if rule.name == token.text:
-                    return lsp_types.Hover(
-                        contents=utils.markdown_content(
-                            f"""*Rule name* = "{rule.name}"
+                    rule_doc = f"""*Rule name* = "{rule.name}"
 
 ```
 {rule.text}
@@ -58,12 +80,27 @@ class Hoverer:
 {rule.condition.text}
 ```
 """
-                        )
-                    )
+
+                    eval_result = await self.eval_expression(rule.name)
+                    if eval_result:
+                        rule_doc = f"{self.result_to_markdown(eval_result)}\n{rule_doc}"
+
+                    return lsp_types.Hover(contents=utils.markdown_content(rule_doc))
         elif token.type in [
             yaramod.TokenType.ValueSymbol,
             yaramod.TokenType.StructureSymbol,
             yaramod.TokenType.FunctionSymbol,
+            yaramod.TokenType.DictionarySymbol,
+            yaramod.TokenType.ArraySymbol,
+            yaramod.TokenType.Lt,
+            yaramod.TokenType.Gt,
+            yaramod.TokenType.Le,
+            yaramod.TokenType.Ge,
+            yaramod.TokenType.Eq,
+            yaramod.TokenType.Neq,
+            yaramod.TokenType.And,
+            yaramod.TokenType.Or,
+            yaramod.TokenType.Not,
         ]:
             return await self.hover_cursor(document, position)
 
@@ -78,24 +115,28 @@ class Hoverer:
 
         hover_string = ""
 
-        eval_result = await self.hover_eval(document, position)
-        if eval_result:
-            eval_result_formatted = f"Evaluation result:\n{eval_result}\n********\n\n"
-            hover_string += eval_result_formatted
+        yara_file = utils.yaramod_parse_file(document.path)
+        if yara_file:
+            expr = utils.cursor_expression(yara_file, position)
+            if expr:
+                eval_result = await self.eval_expression(expr.text)
+                if eval_result:
+                    hover_string += self.result_to_markdown(eval_result)
 
         hover_string += cursor_documentation
 
         return lsp_types.Hover(contents=utils.markdown_content(hover_string))
 
-    async def hover_eval(self, document: Document, position: lsp_types.Position) -> str:
-        log.debug(f'[HOVER] Hover eval "{document}" @ "{position}"')
+    def result_to_markdown(self, result: str) -> str:
+        return f"*Evaluation result*:\n{result}\n********\n\n"
+
+    async def eval_expression(self, expr: str) -> str:
+        log.debug(f'[HOVER] Evaluate expression "{expr}"')
 
         # Evaluate the expression
         eval_result_collected = ""
         eval_results = await utils.pluggy_results(
-            PluginManagerProvider.instance().hook.yls_eval(
-                ls=self.ls, document=document, position=position
-            )
+            PluginManagerProvider.instance().hook.yls_eval(ls=self.ls, expr=expr)
         )
         for eval_result in eval_results:
             # Handle errors from the plugins
@@ -126,7 +167,7 @@ class Hoverer:
 
         return doc
 
-    def hover_string(
+    async def hover_string(
         self, token: yaramod.Token, document: Document, position: lsp_types.Position
     ) -> lsp_types.Hover | None:
         """Generate Hover for string"""
@@ -138,8 +179,12 @@ class Hoverer:
         for string in cur_rule.strings:
             # NOTE: Check the type of string
             if string.identifier == token.pure_text:
-                return lsp_types.Hover(
-                    contents=utils.markdown_content(f"{string.identifier} = {string.text}")
-                )
+                string_doc = f"{string.identifier} = {string.text}"
+
+                eval_result = await self.eval_expression(string.identifier)
+                if eval_result:
+                    string_doc = f"{self.result_to_markdown(eval_result)}\n{string_doc}"
+
+                return lsp_types.Hover(contents=utils.markdown_content(string_doc))
 
         return None

--- a/yls/hover.py
+++ b/yls/hover.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class Hoverer:
     def __init__(self, ls: Any) -> None:
         self.ls = ls
-        self.selected_range = None
+        self.selected_range: lsp_types.Range | None = None
 
     async def hover(self, params: lsp_types.TextDocumentPositionParams) -> lsp_types.Hover | None:
 
@@ -39,15 +39,18 @@ class Hoverer:
                 return None
 
             expr = utils.text_from_range(document, expr_range)
-            log.debug('[HOVER] Hover request with selected text "{}"'.format(expr))
+            log.debug(f'[HOVER] Hover request with selected text "{expr}"')
             eval_result = await self.eval_expression(expr)
             log.debug(f"[HOVER] Evaluation returned {eval_result}")
             return lsp_types.Hover(
                 contents=utils.markdown_content(
-                    "{}\n"
-                    "*Expression*:\n```\n{}\n```\n\n".format(
-                        self.result_to_markdown(eval_result), utils.display_oneline_expr(expr)
-                    )
+                    f"""{self.result_to_markdown(eval_result)}
+*Expression*:
+```
+{utils.display_oneline_expr(expr)}
+```
+
+"""
                 )
             )
 

--- a/yls/utils.py
+++ b/yls/utils.py
@@ -10,7 +10,7 @@ import platform
 import re
 import sys
 import uuid
-from typing import Any
+from typing import Any, List, Optional
 from typing import Iterator
 from typing import TypeVar
 
@@ -83,7 +83,7 @@ def logging_prolog(plugin_manager: PluginManager) -> None:
     log.info(f"YLS version: {__version__}")
     log.info(f"Yaramod version: {yaramod.YARAMOD_VERSION}")
 
-    plugins = ', '.join(plugin[0] for plugin in plugin_manager.list_name_plugin())
+    plugins = ", ".join(plugin[0] for plugin in plugin_manager.list_name_plugin())
     log.info(f"Activated plugins: {plugins}")
 
 
@@ -304,12 +304,15 @@ def is_in_yara_section(document: Document, cursor_line: int, section_name: str) 
 def position_in_range(position: lsp_types.Position, _range: lsp_types.Range) -> bool:
     """Returns if a given position is contained within the specified range."""
     return (
-        _range.start.line <= position.line <= _range.end.line
-        and _range.start.character <= position.character <= _range.end.character
+        _range.start.line < position.line
+        or (_range.start.line == position.line and _range.start.character <= position.character)
+    ) and (
+        _range.end.line > position.line
+        or (_range.end.line == position.line and _range.end.character >= position.character)
     )
 
 
-class YaramodExpressionExtractor(yaramod.ObservingVisitor):  # type: ignore
+class YaramodExpressionExtractor(yaramod.ObservingVisitor):
     """Helper to extract interesting expressions."""
 
     def __init__(self, position: lsp_types.Position) -> None:
@@ -317,7 +320,7 @@ class YaramodExpressionExtractor(yaramod.ObservingVisitor):  # type: ignore
         self.position = position
         self.expr = None
 
-    def run(self, condition: yaramod.Expression) -> yaramod.Expression | None:
+    def run(self, condition: yaramod.Expression) -> Optional[yaramod.Expression]:
         self.observe(condition)
         return self.expr
 
@@ -331,28 +334,116 @@ class YaramodExpressionExtractor(yaramod.ObservingVisitor):  # type: ignore
         self.extract(expr)
 
     # pylint: disable-next=invalid-name
-    def visit_EqExpression(self, expr: yaramod.EqExpression) -> None:
+    def visit_IdExpression(self, expr: yaramod.IdExpression) -> None:
         self.extract(expr)
 
     # pylint: disable-next=invalid-name
-    def visit_NeqExpression(self, expr: yaramod.NeqExpression) -> None:
+    def visit_StructAccessExpression(self, expr):
         self.extract(expr)
 
     # pylint: disable-next=invalid-name
-    def visit_GtExpression(self, expr: yaramod.GtExpression) -> None:
+    def visit_ArrayAccessExpression(self, expr):
         self.extract(expr)
 
     # pylint: disable-next=invalid-name
-    def visit_GeExpression(self, expr: yaramod.GeExpression) -> None:
+    def visit_StringExpression(self, expr: yaramod.StringExpression) -> None:
         self.extract(expr)
+
+    # pylint: disable-next=invalid-name
+    def visit_StringCountExpression(self, expr: yaramod.StringCountExpression) -> None:
+        self.extract(expr)
+
+    # pylint: disable-next=invalid-name
+    def visit_StringOffsetExpression(self, expr: yaramod.StringOffsetExpression) -> None:
+        self.extract(expr)
+
+    # pylint: disable-next=invalid-name
+    def visit_StringLengthExpression(self, expr: yaramod.StringLengthExpression) -> None:
+        self.extract(expr)
+
+    # pylint: disable-next=invalid-name
+    def visit_OfExpression(self, expr: yaramod.OfExpression) -> None:
+        self.extract(expr)
+
+    # pylint: disable-next=invalid-name
+    def visit_ForExpression(self, expr: yaramod.ForExpression) -> None:
+        self.extract(expr)
+
+    # pylint: disable-next=invalid-name
+    def visit_IequalsExpression(self, expr: yaramod.IequalsExpression) -> None:
+        self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
 
     # pylint: disable-next=invalid-name
     def visit_LtExpression(self, expr: yaramod.LtExpression) -> None:
         self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
+
+    # pylint: disable-next=invalid-name
+    def visit_GtExpression(self, expr: yaramod.GtExpression) -> None:
+        self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
 
     # pylint: disable-next=invalid-name
     def visit_LeExpression(self, expr: yaramod.LeExpression) -> None:
         self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
+
+    # pylint: disable-next=invalid-name
+    def visit_GeExpression(self, expr: yaramod.GeExpression) -> None:
+        self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
+
+    # pylint: disable-next=invalid-name
+    def visit_EqExpression(self, expr: yaramod.EqExpression) -> None:
+        self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
+
+    # pylint: disable-next=invalid-name
+    def visit_NeqExpression(self, expr: yaramod.NeqExpression) -> None:
+        self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
+
+    # pylint: disable-next=invalid-name
+    def visit_AndExpression(self, expr: yaramod.AndExpression) -> None:
+        self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
+
+    # pylint: disable-next=invalid-name
+    def visit_OrExpression(self, expr: yaramod.OrExpression) -> None:
+        self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
+
+    # pylint: disable-next=invalid-name
+    def visit_NotExpression(self, expr: yaramod.NotExpression) -> None:
+        self.extract(expr)
+        expr.operand.accept(self)
+
+    # pylint: disable-next=invalid-name
+    def visit_DefinedExpression(self, expr: yaramod.DefinedExpression) -> None:
+        self.extract(expr)
+        expr.operand.accept(self)
+
+    # pylint: disable-next=invalid-name
+    def visit_ContainsExpression(self, expr: yaramod.ContainsExpression) -> None:
+        self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
+
+    # pylint: disable-next=invalid-name
+    def visit_MatchesExpression(self, expr: yaramod.MatchesExpression) -> None:
+        self.extract(expr)
+        expr.left_operand.accept(self)
+        expr.right_operand.accept(self)
 
 
 def cursor_expression(
@@ -579,3 +670,87 @@ async def start_progress(ls: Any, msg: str) -> str | None:
         )
 
     return token
+
+
+def extract_rule_context_from_yarafile(yara_file: yaramod.YaraFile, rule: yaramod.Rule) -> str:
+    """Extract specified rule, private rules and modules it is dependent on from YaraFile."""
+    # Find private rule references inside the condition
+    all_rules = yara_file.rules
+
+    def _extract(curr_rule: yaramod.Rule, extracted_rules: List[str]) -> List[str]:
+        # This rule has already been added, remove it before adding it again
+        try:
+            extracted_rules.remove(curr_rule.text)
+        except:
+            pass
+
+        extracted_rules.insert(0, curr_rule.text)
+
+        uppercase_identifiers = [
+            identifier
+            for identifier in re.split("[ \t()]", curr_rule.condition.text)
+            if identifier and identifier == identifier.upper()
+        ]
+        for uppercase_identifier in uppercase_identifiers:
+            for r in all_rules:
+                if r.name == uppercase_identifier:
+                    # Add private rule dependencies
+                    _extract(r, extracted_rules)
+                    break
+
+        return extracted_rules
+
+    rule_context = "\n\n".join(_extract(rule, []))
+
+    # Import only modules that are needed by context
+    imports = "\n".join(
+        [
+            f'import "{module.name}"'
+            for module in yara_file.imports
+            if re.search(rf"\W{module.name}\.", rule_context)
+        ]
+    )
+    if imports:
+        rule_context = imports + "\n\n" + rule_context
+
+    return rule_context
+
+
+def text_from_range(document: Document, expr_range: lsp_types.Range) -> str:
+    """Extract text from `document` which is located in provided `range`"""
+    first_line = document_line(document, expr_range.start.line)
+
+    if expr_range.start.line == expr_range.end.line:
+        return first_line[expr_range.start.character : expr_range.end.character]
+    else:
+        expr = first_line[expr_range.start.character :]
+
+        for line_idx in range(expr_range.start.line + 1, expr_range.end.line):
+            expr += document_line(document, line_idx) + "\n"
+
+        end_line = document_line(document, expr_range.end.line)
+        expr += end_line[0 : expr_range.end.character + 1]
+        return expr
+
+
+def range_to_expression(document, range: lsp_types.Range) -> Optional[lsp_types.Range]:
+    """Converts selected range in expression to the smallest possible Yaramod expression that covers the entire range."""
+    yara_file = yaramod_parse_file(document.path)
+    if yara_file is None:
+        return None
+
+    start = cursor_expression(yara_file, range.start)
+    end = cursor_expression(yara_file, range.end)
+
+    if start and end:
+        return lsp_types.Range(
+            start=range_from_yaramod_expression(start).start,
+            end=range_from_yaramod_expression(end).end,
+        )
+    else:
+        return None
+
+
+def display_oneline_expr(expr_text: str) -> str:
+    """Remove redundant whitespaces to display expression in a single line."""
+    return re.sub("\s+", " ", expr_text)

--- a/yls/utils.py
+++ b/yls/utils.py
@@ -705,11 +705,9 @@ def extract_rule_context_from_yarafile(yara_file: yaramod.YaraFile, rule: yaramo
 
     # Import only modules that are needed by context
     imports = "\n".join(
-        [
-            f'import "{module.name}"'
-            for module in yara_file.imports
-            if re.search(rf"\W{module.name}\.", rule_context)
-        ]
+        f'import "{module.name}"'
+        for module in yara_file.imports
+        if re.search(rf"\W{module.name}\.", rule_context)
     )
     if imports:
         rule_context = imports + "\n\n" + rule_context
@@ -752,6 +750,6 @@ def range_to_expression(document: Document, _range: lsp_types.Range) -> lsp_type
         return None
 
 
-def display_oneline_expr(expr_text: str) -> str:
-    """Remove redundant whitespaces to display expression in a single line."""
-    return re.sub(r"\s+", " ", expr_text)
+def remove_whitespace(text: str) -> str:
+    """Remove redundant whitespaces to display text in a single line."""
+    return re.sub(r"\s+", " ", text)


### PR DESCRIPTION
Support complex expression extraction and evaluation. You can either hover or select an expression.

If you hover it, YLS will guess the boundaries of expression and pass it to evaluator. So, if you hover `==`, `op1 == op2` gets passed to the evaluator. If you hover `op1`, `op1` gets passed to evaluator.

If you select an expression, YLS will again try to auto-adjust the selection and pass the entire expression. Even if you select only `p ==`, `op1 == op2` is evaluated.