### PR TITLE
feat: Remove `set_samples_dir`

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,4 +1,4 @@
-import { commands, ExtensionContext, window, workspace } from "vscode";
+import { ExtensionContext, workspace } from "vscode";
 import {
   Executable,
   LanguageClient,
@@ -10,14 +10,11 @@ let client: LanguageClient;
 export function activate(_context: ExtensionContext) {
   console.log("YARA vscode initialization");
 
-  workspace.onDidChangeConfiguration(event => {
+  workspace.onDidChangeConfiguration((event) => {
     let langServerAffected = event.affectsConfiguration("yls.executablePath");
-    if (langServerAffected)
+    if (langServerAffected) {
       restartLanguageClient();
-
-    let sampleDirAffected = event.affectsConfiguration("yls.yari.samplesDirectory");
-    if (sampleDirAffected)
-      updateSamplesDirectory();
+    }
   });
 
   restartLanguageClient();
@@ -34,9 +31,7 @@ async function restartLanguageClient(): Promise<void> {
   console.log("YLS configuration ", config);
 
   let execPath: string =
-    process.env.YLS_EXECUTABLE_PATH ||
-    config.get("executablePath") ||
-    "yls";
+    process.env.YLS_EXECUTABLE_PATH || config.get("executablePath") || "yls";
   let execArgs: Array<string> = ["-vv"];
 
   console.log("Exec path: ", execPath);
@@ -63,16 +58,6 @@ async function restartLanguageClient(): Promise<void> {
 
   // Start the client. This will also launch the server
   await client.start();
-  window.showInformationMessage("New instance of YLS has been launched");
-
-  // After each restart we have to set the current sample directory for the new client
-  updateSamplesDirectory();
-}
-
-function updateSamplesDirectory(): void {
-  let dir_path = workspace.getConfiguration("yls.yari").get("samplesDirectory");
-  console.log("Local samples directory changed: ", dir_path);
-  commands.executeCommand("yls.eval_set_samples_dir", dir_path);
 }
 
 export function deactivate(): Promise<void> | undefined {

--- a/tests/integration/test_completion.py
+++ b/tests/integration/test_completion.py
@@ -6,6 +6,7 @@ import pytest
 from pygls.lsp import methods
 from pygls.lsp import types
 from pytest_yls.utils import assert_completable
+
 from yls.completion import CONDITION_KEYWORDS
 
 

--- a/tests/unit/test_debugger.py
+++ b/tests/unit/test_debugger.py
@@ -37,10 +37,12 @@ from yls.hookspecs import ErrorMessage
         ),
     ],
 )
-async def test_debugger(expr: str, expected: Any, samples_dir_with_pe) -> None:
+async def test_debugger(mocker, expr: str, expected: Any, samples_dir_with_pe) -> None:
     debugger = Debugger()
-    debugger.set_samples_dir(str(samples_dir_with_pe))
+    ls_mock = mocker.AsyncMock()
+    ls_mock.get_configuration_async.return_value = [str(samples_dir_with_pe)]
     ctx_res = await debugger.set_context(
+        ls_mock,
         "fa6b73d710b5c96df05632ad6b979e787befd257284f986c3264dbbbb0481609",
         """import "pe"
 

--- a/yls/completer.py
+++ b/yls/completer.py
@@ -9,10 +9,10 @@ from pygls.workspace import Document
 
 from yls import completion
 from yls import utils
+from yls.completion import CONDITION_KEYWORDS
 from yls.plugin_manager_provider import PluginManagerProvider
 from yls.strings import estimate_string_type
 from yls.strings import string_modifiers_completion_items
-from yls.completion import CONDITION_KEYWORDS
 
 log = logging.getLogger(__name__)
 

--- a/yls/hookspecs.py
+++ b/yls/hookspecs.py
@@ -126,8 +126,3 @@ def yls_eval(ls: Any, expr: str) -> PluggyRes[str | PopupMessage]:
 @hookspec
 def yls_eval_set_context(ls: Any, _hash: str, ruleset: str) -> PluggyRes[PopupMessage]:
     ...
-
-
-@hookspec
-def yls_eval_set_samples_dir(ls: Any, _dir: str) -> str:
-    ...

--- a/yls/plugin_manager_provider.py
+++ b/yls/plugin_manager_provider.py
@@ -82,14 +82,6 @@ class YlsCorePlugin:
         return False
 
     @hookimpl(trylast=True)
-    def yls_eval_set_samples_dir(
-        self,  # pylint: disable=unused-argument
-        ls: Any,  # pylint: disable=unused-argument
-        _dir: str,
-    ) -> str:
-        return DebuggerProvider().instance().set_samples_dir(_dir)
-
-    @hookimpl(trylast=True)
     def yls_eval(
         self,  # pylint: disable=unused-argument
         ls: Any,  # pylint: disable=unused-argument
@@ -99,12 +91,9 @@ class YlsCorePlugin:
 
     @hookimpl
     def yls_eval_set_context(
-        self,  # pylint: disable=unused-argument
-        ls: Any,  # pylint: disable=unused-argument
-        _hash: str,
-        ruleset: str,
+        self, ls: Any, _hash: str, ruleset: str  # pylint: disable=unused-argument
     ) -> PluggyRes[PopupMessage]:
-        return DebuggerProvider().instance().set_context(_hash, ruleset)
+        return DebuggerProvider().instance().set_context(ls, _hash, ruleset)
 
     @hookimpl
     def yls_eval_enabled(self) -> bool:

--- a/yls/server.py
+++ b/yls/server.py
@@ -50,7 +50,6 @@ class YaraLanguageServer(LanguageServer):
     COMMAND_SCAN = "yls.scan"
     COMMAND_SCAN_ALL = "yls.scan_all"
     COMMAND_EVAL_SET_CONTEXT = "yls.eval_set_context"
-    COMMAND_EVAL_SET_SAMPLES_DIR = "yls.eval_set_samples_dir"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -670,26 +669,6 @@ async def command_eval_set_context(ls: YaraLanguageServer, args: list[Any]) -> N
                 res_set_context.message = f"{utils.DEBUGGER_SOURCES[i]}: {res_set_context.message}"
             log.debug(res_set_context.message)
             res_set_context.show(ls)
-
-
-@SERVER.command(YaraLanguageServer.COMMAND_EVAL_SET_SAMPLES_DIR)
-async def command_eval_set_samples_dir(ls: YaraLanguageServer, args: list[Any]) -> None:
-    utils.log_command(YaraLanguageServer.COMMAND_EVAL_SET_SAMPLES_DIR)
-    log.debug(f"{args=}")
-
-    if len(args) != 1:
-        return
-
-    _dir = args[0]
-
-    res_samples_dirs = await utils.pluggy_results(
-        PluginManagerProvider.instance().hook.yls_eval_set_samples_dir(ls=ls, _dir=_dir)
-    )
-
-    for res_samples_dir in res_samples_dirs:
-        ls.show_message(
-            f"Samples directory changed to {res_samples_dir}", lsp_types.MessageType.Info
-        )
 
 
 def main() -> None:

--- a/yls/utils.py
+++ b/yls/utils.py
@@ -762,3 +762,18 @@ def remove_whitespace(text: str) -> str:
 
 def truncate_message(text: str, limit: int = 150) -> str:
     return (text[:limit] + "..") if len(text) > limit else text
+
+
+async def get_config_from_editor(ls: Any, section: str) -> Any:
+    """Get the configuration from the editor."""
+    config = await ls.get_configuration_async(
+        lsp_types.ConfigurationParams(
+            items=[lsp_types.ConfigurationItem(scope_uri="", section=section)]
+        )
+    )
+
+    # We should get list of configuration items here with exactly one element
+    assert isinstance(config, list)
+    assert len(config) == 1
+
+    return config[0]


### PR DESCRIPTION
We don't need this command/hook. Every time we set the context it will query the settings and search for the samples.