### PR TITLE
feat: Don't show YARI when debugging is not setup

### DIFF
--- a/tests/integration/test_hover.py
+++ b/tests/integration/test_hover.py
@@ -28,6 +28,8 @@ rule test {
         in response_text
     )
 
+    assert not context.get_nofications(methods.WINDOW_SHOW_MESSAGE)
+
 
 def test_hover_string_plain(yls_prepare):
     contents = """rule test {
@@ -48,6 +50,8 @@ def test_hover_string_plain(yls_prepare):
     assert response
     assert "$s" in response["contents"]["value"]
     assert "string" in response["contents"]["value"]
+
+    assert not context.get_nofications(methods.WINDOW_SHOW_MESSAGE)
 
 
 def test_hover_string_hex(yls_prepare):
@@ -70,6 +74,8 @@ def test_hover_string_hex(yls_prepare):
     assert "$h" in response["contents"]["value"]
     assert "12 34 56 78" in response["contents"]["value"]
 
+    assert not context.get_nofications(methods.WINDOW_SHOW_MESSAGE)
+
 
 def test_hover_string_regex(yls_prepare):
     contents = """rule test {
@@ -90,6 +96,8 @@ def test_hover_string_regex(yls_prepare):
     assert response
     assert "$r" in response["contents"]["value"]
     assert "/my.*custom.*regex/" in response["contents"]["value"]
+
+    assert not context.get_nofications(methods.WINDOW_SHOW_MESSAGE)
 
 
 def test_hover_private_rule_same_file(yls_prepare):
@@ -116,6 +124,8 @@ rule test {
     assert "PRIV_TEST" in response["contents"]["value"]
     assert "Condition" in response["contents"]["value"]
 
+    assert not context.get_nofications(methods.WINDOW_SHOW_MESSAGE)
+
 
 def test_hover_constant_symbol_value(yls_prepare):
     contents = """import "pe"
@@ -135,3 +145,5 @@ rule test {
     assert response
     assert "MACHINE_ARM" in response["contents"]["value"]
     assert "int" in response["contents"]["value"]
+
+    assert not context.get_nofications(methods.WINDOW_SHOW_MESSAGE)

--- a/yls/debugger.py
+++ b/yls/debugger.py
@@ -64,7 +64,7 @@ class Debugger:
     def eval(self, expr: str) -> str | PopupMessage:
         log.info(f"[DEBUGGER] Evaluating {expr}")
         if not self.ctxs:
-            return ErrorMessage("YARI is not ready to evaluate... Ignoring evaluation request")
+            return ""
 
         if self.context_rule_name:
             expr = f"{self.context_rule_name}|{expr}"


### PR DESCRIPTION
Currently when no context for debugging is selected, we are showing an error message. Try to silence it.