### PR TITLE
chore: Try to try to fix dependabot by using relative path

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -746,7 +746,7 @@ toml = ">=0.7.1"
 
 [[package]]
 name = "pytest-yls"
-version = "1.2.5"
+version = "1.3.2"
 description = "Pytest plugin to test the YLS as a whole."
 category = "dev"
 optional = false
@@ -755,9 +755,8 @@ files = []
 develop = true
 
 [package.dependencies]
-pytest = "^7.1.2"
+pytest = "^7.2.2"
 tenacity = "^8.0.1"
-yls = {path = ".."}
 
 [package.source]
 type = "directory"
@@ -1035,4 +1034,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "9dba92be9f82d8691644c7569b92b349a840f90a6854ad3bcc6d37c4dc1a7847"
+content-hash = "e32c310a1fdbbc25e3aebf9dd05d1995c20cc727f8cc6accfcf78a7efe6dbe3d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ pytest-cov = "^3.0.0"
 pytest-mock = "^3.7.0"
 pytest-mypy = "^0.9.1"
 pytest-pylint = "0.19.0"
-pytest-yls = {path = "pytest-yls", develop = true}
+pytest-yls = {path = "./pytest-yls", develop = true}
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Updates for the yls package does not work for some reason. In the logs I can see `Directory pytest-yls does not exist`. Searching for similar issue people had similar problem with `file =` not `path =` but they always fixed that to `./<path>` so maybe this is an issue?