### PR TITLE
fix: Incorrect syntax on regexp end

### DIFF
--- a/editors/vscode/language/yara.tmLanguage.json
+++ b/editors/vscode/language/yara.tmLanguage.json
@@ -462,7 +462,7 @@
     "regexp-strings": {
       "name": "string.regexp.yara",
       "begin": "(?<!/)(/)(?!/|\\n)",
-      "end": "(?<!\\\\)(/)(i?s?)|((?:\\\\/)?[^/]*\\n)",
+      "end": "(?<![^\\\\]\\\\)(/)(i?s?)|((?:\\\\/)?[^/]*\\n)",
       "beginCaptures": {
         "1": {"name": "punctuation.definition.regexp.begin.yara"}
       },


### PR DESCRIPTION
Fox example:
```yara
cuckoo.sync.mutex(/test\\/)
```
The last `/` was not detected as a end of string, because we only look at the preceding character is not escaping the end of regexp. But what if there is a another escape.